### PR TITLE
Fix handling of multiple options

### DIFF
--- a/TeXUtilities/TeXUtilities.m
+++ b/TeXUtilities/TeXUtilities.m
@@ -169,7 +169,7 @@ TeXDelimited /: MakeBoxes[
 	TeXDelimited[start_String, body___, end_String, opts : OptionsPattern[]],
 	TraditionalForm
 ] := Module[{bodyConv, bodySep, delSep, indent},
-	{bodyConv, bodySep, delSep, indent} = OptionValue[TeXDelimited, opts,
+	{bodyConv, bodySep, delSep, indent} = OptionValue[TeXDelimited, {opts},
 		{"BodyConverter", "BodySeparator", "DelimSeparator", "Indentation"}
 	];
 	ToBoxes[
@@ -240,7 +240,7 @@ TeXCommand[name_, args : Except@_List, rest___] := (
 TeXCommand /: MakeBoxes[
 	TeXCommand[name_String, args_List : {}, opts : OptionsPattern[]],
 	TraditionalForm
-] := With[{argConv = OptionValue[TeXCommand, opts, "ArgumentConverter"]},
+] := With[{argConv = OptionValue[TeXCommand, {opts}, "ArgumentConverter"]},
 	ToBoxes[
 		TeXVerbatim@StringJoin["\\", name,
 			teXCommandArgument[#, argConv]& /@ args
@@ -285,7 +285,7 @@ TeXEnvironment /: MakeBoxes[
 	]
 	,
 	TraditionalForm
-] := With[{argConv = OptionValue[TeXEnvironment, opts, "ArgumentConverter"]},
+] := With[{argConv = OptionValue[TeXEnvironment, {opts}, "ArgumentConverter"]},
 	ToBoxes[
 		TeXDelimited[
 			StringJoin[

--- a/TeXUtilities/Tests/TeXCommand.mt
+++ b/TeXUtilities/Tests/TeXCommand.mt
@@ -158,6 +158,16 @@ Test[
 	"\\name[a=$b$,c]{\\d}",
 	TestID -> "TeX conversion: \"ArgumentConverter\" option: ToString"
 ]
+Test[
+	ToString[TeXCommand["name", {a, {b -> c}, d},
+		"ArgumentConverter" -> ("\\f{" <> ToString@# <> "}"&),
+		"ArgumentConverter" -> ToString
+	], TeXForm]
+	,
+	"\\name{\\f{a}}[\\f{b}=\\f{c}]{\\f{d}}"
+	,
+	TestID -> "TeX conversion: \"ArgumentConverter\" option: two values"
+]
 
 
 (* ::Section:: *)

--- a/TeXUtilities/Tests/TeXDelimited.mt
+++ b/TeXUtilities/Tests/TeXDelimited.mt
@@ -273,6 +273,34 @@ Test[
 	TestID -> "TeX conversion: \"Indentation\" option: \t, two spaces"
 ]
 
+Test[
+	ToString[
+		TeXDelimited[
+			"\\left",
+			"expr1",
+			"expr2",
+			"expr3",
+			"expr4",
+			"\\right",
+			"BodyConverter" -> ("\\macro{" <> ToString@# <> "}" &),
+			"BodySeparator" -> " \\, ",
+			"DelimSeparator" -> "\n\n",
+			"Indentation" -> "  "
+		]
+		,
+		TeXForm
+	]
+	,
+	"\
+\\left
+  
+  \\macro{expr1} \\, \\macro{expr2} \\, \\macro{expr3} \\, \\macro{expr4}
+
+\\right"
+	,
+	TestID -> "TeX conversion: all options"
+]
+
 
 (* ::Section:: *)
 (*TearDown*)

--- a/TeXUtilities/Tests/TeXEnvironment.mt
+++ b/TeXUtilities/Tests/TeXEnvironment.mt
@@ -270,6 +270,35 @@ Test[
 	TestID -> "TeX conversion: \"Indentation\" option: \t, two spaces"
 ]
 
+Test[
+	ToString[
+		TeXEnvironment[
+			{"myEnv", {{x -> y}, z},
+				"ArgumentConverter" -> ("\\arg{" <> ToString@# <> "}" &),
+				"BodyConverter" -> ("\\body{" <> ToString@# <> "}" &),
+				"BodySeparator" -> " \\, ",
+				"DelimSeparator" -> "\n\n",
+				"Indentation" -> "  "
+			}, 
+			"expr1",
+			"expr2",
+			"expr3",
+			"expr4"
+		]
+		,
+		TeXForm
+	]
+	,
+	"\
+\\begin{myEnv}[\\arg{x}=\\arg{y}]{\\arg{z}}
+  
+  \\body{expr1} \\, \\body{expr2} \\, \\body{expr3} \\, \\body{expr4}
+
+\\end{myEnv}"
+	,
+	TestID -> "TeX conversion: all options"
+]
+
 
 (* ::Section:: *)
 (*TearDown*)


### PR DESCRIPTION
Fix handling of multiple options and add appropriate tests.

Before this fix passing more than one option to `TeXDelimited`, `TeXCommand`, or `TeXEnvironment` resulted in errors.